### PR TITLE
Make app_name parameter to CreateProcess a string.

### DIFF
--- a/lib/windows/process.rb
+++ b/lib/windows/process.rb
@@ -111,7 +111,7 @@ module Windows
 
     API.new('AssignProcessToJobObject', 'LL', 'B')
     API.new('CreateJobObject', 'PS', 'L')
-    API.new('CreateProcess', 'PPPPLLLPPP', 'B')
+    API.new('CreateProcess', 'SPPPLLLPPP', 'B')
     API.new('CreateProcessAsUser', 'LPPLLILPPPP', 'B', 'advapi32')
     API.new('CreateProcessWithLogonW', 'PPPLPPLLPPP', 'B', 'advapi32')
     API.new('EnumProcesses', 'PLP', 'B', 'psapi')


### PR DESCRIPTION
Make app_name parameter to CreateProcess a string.  This allows both :app_name and :command_line to be passed together to Process.create.
