### PR TITLE
Stop using eval for float conversion

### DIFF
--- a/lib/windows/system_info.rb
+++ b/lib/windows/system_info.rb
@@ -123,7 +123,7 @@ module Windows
       version = GetVersion()
       major = LOBYTE(LOWORD(version))
       minor = HIBYTE(LOWORD(version))
-      eval("Float(#{major}.#{minor})")
+      "#{major}.#{minor}".to_f
     end
 
     # Custom methods that may come in handy


### PR DESCRIPTION
eval() is pretty evil and is overkill for converting a string into a
float. This could also be done with just a little math, which would be
even better, but I think .to_f is clear enough.
