### PR TITLE
Migrate bundler based project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.bundle/
+Gemfile.lock
+/vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/windows-pr.gemspec
+++ b/windows-pr.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
     'doc/conversion_guide.txt'
   ]
 
+  spec.add_development_dependency('minitest', '~> 5.9.0')
   spec.add_dependency('windows-api', '>= 0.4.0')
   spec.add_dependency('win32-api', '>= 1.4.5')
 


### PR DESCRIPTION
Also I want to tidy up gem dependency with bundler.
But for now, I got the following tests failed:

* Windows 7 32bit CP932 (Japanese)
* Ruby 2.2.4

```log
> bundle exec rake test:all
# Running:

.........................F....F.................................................
................................................................................
............

Finished in 0.456015s, 377.1808 runs/s, 1767.4867 assertions/s.

  1) Failure:
TC_Windows_Unicode#test_multi_to_wide [C:/Users/hhatake/Documents/GitHub/windows
-pr/test/tc_unicode.rb:49]:
--- expected
+++ actual
@@ -1,2 +1,2 @@
 # encoding: ASCII-8BIT
-"\xCE\x00\" \xCE\x00\xBB\x00\xCE\x00\xBB\x00\xCE\x00\xAC\x00\xCF\x00\x92\x01\x0
0\x00"
+"\x8E\xFFOP{\xFF\x8E\xFF{\xFF\x8E\xFFl\xFF\x8F\xFF\xFB0\x00\x00"



  2) Failure:
TC_Windows_Unicode#test_wide_to_multi [C:/Users/hhatake/Documents/GitHub/windows
-pr/test/tc_unicode.rb:69]:
--- expected
+++ actual
@@ -1,2 +1,2 @@
 # encoding: ASCII-8BIT
-"\xCE\x95\xCE\xBB\xCE\xBB\xCE\xAC\xCF\x83"
+"I?I\x81\xE2I\x81\xE2I\x81\xCAI?"


172 runs, 806 assertions, 2 failures, 0 errors, 0 skips
rake aborted!
```