### PR TITLE
Suppress warnings

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,4 @@
+require 'minitest/autorun'
 require 'minitest/unit'
 
 module Minitest::Assertions

--- a/test/tc_clipboard.rb
+++ b/test/tc_clipboard.rb
@@ -6,7 +6,7 @@
 require 'windows/clipboard'
 require 'minitest/autorun'
 
-class TC_Windows_Clipboard < MiniTest::Unit::TestCase
+class TC_Windows_Clipboard < MiniTest::Test
    include Windows::Clipboard
 
    def test_methods

--- a/test/tc_com.rb
+++ b/test/tc_com.rb
@@ -6,7 +6,7 @@
 require "windows/com"
 require "minitest/autorun"
 
-class TC_Windows_COM < MiniTest::Unit::TestCase
+class TC_Windows_COM < MiniTest::Test
    include Windows::COM
 
    def test_method_constants

--- a/test/tc_com_automation.rb
+++ b/test/tc_com_automation.rb
@@ -6,7 +6,7 @@
 require 'windows/com/automation'
 require 'minitest/autorun'
 
-class TC_Windows_COM_Automation < MiniTest::Unit::TestCase
+class TC_Windows_COM_Automation < MiniTest::Test
    include Windows::COM::Automation
 
    def test_method_constants

--- a/test/tc_console.rb
+++ b/test/tc_console.rb
@@ -6,7 +6,7 @@
 require 'windows/console'
 require 'minitest/autorun'
 
-class TC_Windows_Console < MiniTest::Unit::TestCase
+class TC_Windows_Console < MiniTest::Test
    include Windows::Console
 
    def setup

--- a/test/tc_debug.rb
+++ b/test/tc_debug.rb
@@ -10,7 +10,7 @@ class DebugFoo
    include Windows::Debug
 end
 
-class TC_Windows_Debug < MiniTest::Unit::TestCase
+class TC_Windows_Debug < MiniTest::Test
    def setup
       @foo = DebugFoo.new
       @ver = `ver`.chomp

--- a/test/tc_device_io.rb
+++ b/test/tc_device_io.rb
@@ -10,7 +10,7 @@ class DeviceIOFoo
    include Windows::DeviceIO
 end
 
-class TC_Windows_DeviceIO < MiniTest::Unit::TestCase
+class TC_Windows_DeviceIO < MiniTest::Test
    def setup
       @foo  = DeviceIOFoo.new
    end

--- a/test/tc_directory.rb
+++ b/test/tc_directory.rb
@@ -10,7 +10,7 @@ class DirectoryFoo
    include Windows::Directory
 end
 
-class TC_Windows_Directory < MiniTest::Unit::TestCase
+class TC_Windows_Directory < MiniTest::Test
    def setup
       @foo  = DirectoryFoo.new
    end

--- a/test/tc_error.rb
+++ b/test/tc_error.rb
@@ -6,7 +6,7 @@
 require "windows/error"
 require "minitest/autorun"
 
-class TC_Windows_Error < MiniTest::Unit::TestCase
+class TC_Windows_Error < MiniTest::Test
   include Windows::Error
 
   def test_numeric_constants

--- a/test/tc_eventlog.rb
+++ b/test/tc_eventlog.rb
@@ -10,7 +10,7 @@ class EventLogFoo
    include Windows::EventLog
 end
 
-class TC_Windows_EventLog < MiniTest::Unit::TestCase
+class TC_Windows_EventLog < MiniTest::Test
    def setup
       @foo = EventLogFoo.new
    end

--- a/test/tc_file.rb
+++ b/test/tc_file.rb
@@ -10,7 +10,7 @@ class FileFoo
   include Windows::File
 end
 
-class TC_Windows_File < MiniTest::Unit::TestCase
+class TC_Windows_File < MiniTest::Test
 
    def setup
       @foo = FileFoo.new

--- a/test/tc_file_mapping.rb
+++ b/test/tc_file_mapping.rb
@@ -10,7 +10,7 @@ class FileMappingFoo
   include Windows::FileMapping
 end
 
-class TC_Windows_FileMapping < MiniTest::Unit::TestCase
+class TC_Windows_FileMapping < MiniTest::Test
 
    def setup
       @foo = FileMappingFoo.new

--- a/test/tc_filesystem.rb
+++ b/test/tc_filesystem.rb
@@ -10,7 +10,7 @@ class FileSystemFoo
   include Windows::FileSystem
 end
 
-class TC_Windows_FileSystem < MiniTest::Unit::TestCase
+class TC_Windows_FileSystem < MiniTest::Test
 
    def setup
       @foo = FileSystemFoo.new

--- a/test/tc_gdi_bitmap.rb
+++ b/test/tc_gdi_bitmap.rb
@@ -6,7 +6,7 @@
 require 'windows/gdi/bitmap'
 require 'minitest/autorun'
 
-class TC_Windows_GDI_Bitmap < MiniTest::Unit::TestCase
+class TC_Windows_GDI_Bitmap < MiniTest::Test
    include Windows::GDI::Bitmap
 
    def test_methods

--- a/test/tc_gdi_metafile.rb
+++ b/test/tc_gdi_metafile.rb
@@ -6,7 +6,7 @@
 require 'windows/gdi/metafile'
 require 'minitest/autorun'
 
-class TC_Windows_GDI_MetaFile < MiniTest::Unit::TestCase
+class TC_Windows_GDI_MetaFile < MiniTest::Test
    include Windows::GDI::MetaFile
 
    def test_methods

--- a/test/tc_handle.rb
+++ b/test/tc_handle.rb
@@ -10,7 +10,7 @@ class HandleFoo
   include Windows::Handle
 end
 
-class TC_Windows_Handle < MiniTest::Unit::TestCase
+class TC_Windows_Handle < MiniTest::Test
    def setup
       @foo = HandleFoo.new
    end

--- a/test/tc_library.rb
+++ b/test/tc_library.rb
@@ -10,7 +10,7 @@ class LibraryFoo
   include Windows::Library
 end
 
-class TC_Windows_Library < MiniTest::Unit::TestCase
+class TC_Windows_Library < MiniTest::Test
    def setup
       @LibraryFoo  = LibraryFoo.new
    end

--- a/test/tc_limits.rb
+++ b/test/tc_limits.rb
@@ -10,7 +10,7 @@ class LimitsFoo
   include Windows::Limits
 end
 
-class TC_Windows_Limits < MiniTest::Unit::TestCase
+class TC_Windows_Limits < MiniTest::Test
    def setup
       @foo = LimitsFoo.new
    end

--- a/test/tc_mailslot.rb
+++ b/test/tc_mailslot.rb
@@ -6,7 +6,7 @@
 require 'windows/mailslot'
 require 'minitest/autorun'
 
-class TC_Windows_Mailslot < MiniTest::Unit::TestCase
+class TC_Windows_Mailslot < MiniTest::Test
    include Windows::Mailslot
 
    def test_constants

--- a/test/tc_memory.rb
+++ b/test/tc_memory.rb
@@ -10,7 +10,7 @@ class MemoryFoo
    include Windows::Memory
 end
 
-class TC_Windows_Memory < MiniTest::Unit::TestCase
+class TC_Windows_Memory < MiniTest::Test
    def setup
       @foo  = MemoryFoo.new
       @path = "C:\\"

--- a/test/tc_msvcrt_buffer.rb
+++ b/test/tc_msvcrt_buffer.rb
@@ -7,7 +7,7 @@ require 'rubygems'
 require 'windows/msvcrt/buffer'
 require 'minitest/autorun'
 
-class TC_Windows_MSVCRT_Buffer < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_Buffer < MiniTest::Test
   include Windows::MSVCRT::Buffer
 
   def test_method_constants

--- a/test/tc_msvcrt_directory.rb
+++ b/test/tc_msvcrt_directory.rb
@@ -7,7 +7,7 @@ require 'windows/msvcrt/directory'
 require 'fileutils'
 require 'minitest/autorun'
 
-class TC_Windows_MSVCRT_Directory < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_Directory < MiniTest::Test
   include Windows::MSVCRT::Directory
 
   def setup

--- a/test/tc_msvcrt_file.rb
+++ b/test/tc_msvcrt_file.rb
@@ -10,7 +10,7 @@ class MFileFoo
    include Windows::MSVCRT::File
 end
 
-class TC_Windows_MSVCRT_File < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_File < MiniTest::Test
    def setup
       @foo = MFileFoo.new
    end

--- a/test/tc_msvcrt_io.rb
+++ b/test/tc_msvcrt_io.rb
@@ -10,7 +10,7 @@ class MIOFoo
    include Windows::MSVCRT::IO
 end
 
-class TC_Windows_MSVCRT_IO < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_IO < MiniTest::Test
    def setup
       @foo = MIOFoo.new
    end

--- a/test/tc_msvcrt_string.rb
+++ b/test/tc_msvcrt_string.rb
@@ -6,7 +6,7 @@
 require 'windows/msvcrt/string'
 require 'minitest/autorun'
 
-class TC_Windows_MSVCRT_String < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_String < MiniTest::Test
   include Windows::MSVCRT::String
 
   def setup

--- a/test/tc_msvcrt_time.rb
+++ b/test/tc_msvcrt_time.rb
@@ -6,7 +6,7 @@
 require 'windows/msvcrt/time'
 require 'minitest/autorun'
 
-class TC_Windows_MSVCRT_Time < MiniTest::Unit::TestCase
+class TC_Windows_MSVCRT_Time < MiniTest::Test
   include Windows::MSVCRT::Time
 
   def test_method_constants

--- a/test/tc_national.rb
+++ b/test/tc_national.rb
@@ -10,7 +10,7 @@ class NationalFoo
   include Windows::National
 end
 
-class TC_Windows_National < MiniTest::Unit::TestCase
+class TC_Windows_National < MiniTest::Test
    def setup
       @foo = NationalFoo.new
    end

--- a/test/tc_network_management.rb
+++ b/test/tc_network_management.rb
@@ -10,7 +10,7 @@ class NetworkManagementFoo
   include Windows::Network::Management
 end
 
-class TC_Windows_Network_Management < MiniTest::Unit::TestCase
+class TC_Windows_Network_Management < MiniTest::Test
    def setup
       @foo = NetworkManagementFoo.new
    end

--- a/test/tc_network_snmp.rb
+++ b/test/tc_network_snmp.rb
@@ -10,7 +10,7 @@ class NetworkSNMPFoo
    include Windows::Network::SNMP
 end
 
-class TC_Windows_Network_SNMP < MiniTest::Unit::TestCase
+class TC_Windows_Network_SNMP < MiniTest::Test
    def setup
       @foo = NetworkSNMPFoo.new
    end

--- a/test/tc_network_winsock.rb
+++ b/test/tc_network_winsock.rb
@@ -10,7 +10,7 @@ class WinsockFoo
    include Windows::Network::Winsock
 end
 
-class TC_Windows_Network_Winsock < MiniTest::Unit::TestCase
+class TC_Windows_Network_Winsock < MiniTest::Test
    def setup
       @foo = WinsockFoo.new
    end

--- a/test/tc_nio.rb
+++ b/test/tc_nio.rb
@@ -10,7 +10,7 @@ class NIOFoo
    include Windows::NIO
 end
 
-class TC_Windows_NIO < MiniTest::Unit::TestCase
+class TC_Windows_NIO < MiniTest::Test
    def setup
       @foo = NIOFoo.new
    end

--- a/test/tc_ntfs_winternl.rb
+++ b/test/tc_ntfs_winternl.rb
@@ -8,7 +8,7 @@ require 'windows/ntfs/winternl'
 require 'windows/error'
 require 'minitest/autorun'
 
-class TC_Windows_NTFS_Winternl < MiniTest::Unit::TestCase
+class TC_Windows_NTFS_Winternl < MiniTest::Test
   include Windows::Handle
   include Windows::NTFS::Winternl
   include Windows::Error

--- a/test/tc_path.rb
+++ b/test/tc_path.rb
@@ -10,7 +10,7 @@ class PathFoo
    include Windows::Path
 end
 
-class TC_Windows_Path < MiniTest::Unit::TestCase
+class TC_Windows_Path < MiniTest::Test
    def setup
       @foo  = PathFoo.new
       @path = "C:\\"

--- a/test/tc_pipe.rb
+++ b/test/tc_pipe.rb
@@ -10,7 +10,7 @@ class PipeFoo
    include Windows::Pipe
 end
 
-class TC_Windows_Pipe < MiniTest::Unit::TestCase
+class TC_Windows_Pipe < MiniTest::Test
    def setup
       @foo = PipeFoo.new
    end

--- a/test/tc_process.rb
+++ b/test/tc_process.rb
@@ -6,7 +6,7 @@
 require 'windows/process'
 require 'minitest/autorun'
 
-class TC_Windows_Process < MiniTest::Unit::TestCase
+class TC_Windows_Process < MiniTest::Test
   include Windows::Process
 
   def test_constants

--- a/test/tc_registry.rb
+++ b/test/tc_registry.rb
@@ -10,7 +10,7 @@ class RegistryFoo
    include Windows::Registry
 end
 
-class TC_Windows_Registry < MiniTest::Unit::TestCase
+class TC_Windows_Registry < MiniTest::Test
    def setup
       @foo  = RegistryFoo.new
    end

--- a/test/tc_security.rb
+++ b/test/tc_security.rb
@@ -10,7 +10,7 @@ class SecurityFoo
    include Windows::Security
 end
 
-class TC_Windows_Security < MiniTest::Unit::TestCase
+class TC_Windows_Security < MiniTest::Test
    def setup
       @foo = SecurityFoo.new
    end

--- a/test/tc_security_authentication.rb
+++ b/test/tc_security_authentication.rb
@@ -6,7 +6,7 @@
 require 'windows/security/authentication'
 require 'minitest/autorun'
 
-class TC_Windows_Security_Authentication < MiniTest::Unit::TestCase
+class TC_Windows_Security_Authentication < MiniTest::Test
 
    include Windows::Security::Authentication
 

--- a/test/tc_security_sspi.rb
+++ b/test/tc_security_sspi.rb
@@ -6,7 +6,7 @@
 require 'windows/security/SSPI'
 require 'minitest/autorun'
 
-class TC_Windows_Security_SSPI < MiniTest::Unit::TestCase
+class TC_Windows_Security_SSPI < MiniTest::Test
   include Windows::Security::SSPI
 
   def test_methods

--- a/test/tc_service.rb
+++ b/test/tc_service.rb
@@ -10,7 +10,7 @@ class ServiceFoo
    include Windows::Service
 end
 
-class TC_Windows_Service < MiniTest::Unit::TestCase
+class TC_Windows_Service < MiniTest::Test
    def setup
       @foo = ServiceFoo.new
    end

--- a/test/tc_shell.rb
+++ b/test/tc_shell.rb
@@ -10,7 +10,7 @@ class ShellFoo
    include Windows::Shell
 end
 
-class TC_Windows_Shell < MiniTest::Unit::TestCase
+class TC_Windows_Shell < MiniTest::Test
    def setup
       @foo = ShellFoo.new
    end

--- a/test/tc_socket.rb
+++ b/test/tc_socket.rb
@@ -10,7 +10,7 @@ class SocketFoo
   include Windows::Socket
 end
 
-class TC_Windows_Socket < MiniTest::Unit::TestCase
+class TC_Windows_Socket < MiniTest::Test
   def setup
     @socket = SocketFoo.new
   end

--- a/test/tc_sound.rb
+++ b/test/tc_sound.rb
@@ -10,7 +10,7 @@ class SoundFoo
    include Windows::Sound
 end
 
-class TC_Windows_Sound < MiniTest::Unit::TestCase
+class TC_Windows_Sound < MiniTest::Test
    def setup
       @foo = SoundFoo.new
    end

--- a/test/tc_synchronize.rb
+++ b/test/tc_synchronize.rb
@@ -6,7 +6,7 @@
 require "windows/synchronize"
 require "minitest/autorun"
 
-class TC_Windows_Synchronize < MiniTest::Unit::TestCase
+class TC_Windows_Synchronize < MiniTest::Test
   include Windows::Synchronize
 
   def setup

--- a/test/tc_system_info.rb
+++ b/test/tc_system_info.rb
@@ -6,7 +6,7 @@
 require 'windows/system_info'
 require 'minitest/autorun'
 
-class TC_Windows_SystemInfo < MiniTest::Unit::TestCase
+class TC_Windows_SystemInfo < MiniTest::Test
   include Windows::SystemInfo
 
   def test_numeric_constants

--- a/test/tc_thread.rb
+++ b/test/tc_thread.rb
@@ -10,7 +10,7 @@ class ThreadFoo
    include Windows::Thread
 end
 
-class TC_Windows_Thread < MiniTest::Unit::TestCase
+class TC_Windows_Thread < MiniTest::Test
    def setup
       @foo  = ThreadFoo.new
    end

--- a/test/tc_time.rb
+++ b/test/tc_time.rb
@@ -10,7 +10,7 @@ class TimeFoo
    include Windows::Time
 end
 
-class TC_Windows_Time < MiniTest::Unit::TestCase
+class TC_Windows_Time < MiniTest::Test
    def setup
       @foo = TimeFoo.new
    end

--- a/test/tc_tool_helper.rb
+++ b/test/tc_tool_helper.rb
@@ -10,7 +10,7 @@ class ToolHelperFoo
    include Windows::ToolHelper
 end
 
-class TC_Windows_ToolHelper < MiniTest::Unit::TestCase
+class TC_Windows_ToolHelper < MiniTest::Test
    def setup
       @foo  = ToolHelperFoo.new
    end

--- a/test/tc_unicode.rb
+++ b/test/tc_unicode.rb
@@ -7,7 +7,7 @@
 require "windows/unicode"
 require "minitest/autorun"
 
-class TC_Windows_Unicode < MiniTest::Unit::TestCase
+class TC_Windows_Unicode < MiniTest::Test
   include Windows::Unicode
 
   def test_numeric_constants

--- a/test/tc_volume.rb
+++ b/test/tc_volume.rb
@@ -6,7 +6,7 @@
 require 'windows/volume'
 require 'minitest/unit'
 
-class TC_Windows_Volume < MiniTest::Unit::TestCase
+class TC_Windows_Volume < MiniTest::Test
   include Windows::Volume
 
   def test_constants

--- a/test/tc_window.rb
+++ b/test/tc_window.rb
@@ -10,7 +10,7 @@ class WindowFoo
    include Windows::Window
 end
 
-class TC_Windows_Window < MiniTest::Unit::TestCase
+class TC_Windows_Window < MiniTest::Test
    def setup
       @foo = WindowFoo.new
    end

--- a/test/tc_window_classes.rb
+++ b/test/tc_window_classes.rb
@@ -10,7 +10,7 @@ class WindowClassesFoo
    include Windows::Window::Classes
 end
 
-class TC_Windows_Window_Classes < MiniTest::Unit::TestCase
+class TC_Windows_Window_Classes < MiniTest::Test
    def setup
       @foo = WindowClassesFoo.new
    end

--- a/test/tc_window_dialog.rb
+++ b/test/tc_window_dialog.rb
@@ -10,7 +10,7 @@ class WindowDialogFoo
    include Windows::Window::Dialog
 end
 
-class TC_Windows_Window_Dialog < MiniTest::Unit::TestCase
+class TC_Windows_Window_Dialog < MiniTest::Test
    def setup
       @foo = WindowDialogFoo.new
    end

--- a/test/tc_window_menu.rb
+++ b/test/tc_window_menu.rb
@@ -10,7 +10,7 @@ class WindowMenuFoo
    include Windows::Window::Menu
 end
 
-class TC_Windows_Window_Menu < MiniTest::Unit::TestCase
+class TC_Windows_Window_Menu < MiniTest::Test
    def setup
       @foo = WindowMenuFoo.new
    end

--- a/test/tc_window_message.rb
+++ b/test/tc_window_message.rb
@@ -10,7 +10,7 @@ class WindowMessageFoo
    include Windows::Window::Message
 end
 
-class TC_Windows_Window_Message < MiniTest::Unit::TestCase
+class TC_Windows_Window_Message < MiniTest::Test
    def setup
       @foo = WindowMessageFoo.new
    end

--- a/test/tc_window_properties.rb
+++ b/test/tc_window_properties.rb
@@ -10,7 +10,7 @@ class WindowPropertiesFoo
    include Windows::Window::Properties
 end
 
-class TC_Windows_Window_Properties < MiniTest::Unit::TestCase
+class TC_Windows_Window_Properties < MiniTest::Test
    def setup
       @foo = WindowPropertiesFoo.new
    end

--- a/test/tc_window_timer.rb
+++ b/test/tc_window_timer.rb
@@ -10,7 +10,7 @@ class WindowTimerFoo
    include Windows::Window::Timer
 end
 
-class TC_Windows_Window_Timer < MiniTest::Unit::TestCase
+class TC_Windows_Window_Timer < MiniTest::Test
    def setup
       @foo = WindowTimerFoo.new
    end

--- a/test/tc_wsa.rb
+++ b/test/tc_wsa.rb
@@ -6,7 +6,7 @@
 require 'windows/wsa'
 require 'minitest/autorun'
 
-class TC_Windows_WSA < MiniTest::Unit::TestCase
+class TC_Windows_WSA < MiniTest::Test
   include Windows::WSA
 
   def test_methods


### PR DESCRIPTION
Appveyor CI complains the following warnings:

```log
Warning: you should require 'minitest/autorun' instead. 
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"' 
From:
  C:/projects/windows-pr/test/helper.rb:1:in `require'
  C:/projects/windows-pr/test/helper.rb:1:in `<top (required)>'
  C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in `require'
  C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in `block in <main>'
  C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in `select'
  C:/Ruby23-x64/lib/ruby/gems/2.3.0/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in `<main>' 
MiniTest::Unit::TestCase is now Minitest::Test. From C:/projects/windows-pr/test/tc_clipboard.rb:9:in `<top (required)>'
...
(snip)
...
MiniTest::Unit::TestCase is now Minitest::Test. From C:/projects/windows-pr/test/tc_wsa.rb:9:in `<top (required)>' 
```

We should suppress them.