### PR TITLE
Use git committed files to files metadata

### DIFF
--- a/windows-pr.gemspec
+++ b/windows-pr.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.homepage   = 'https://github.com/djberg96/windows-pr'
   spec.summary    = 'Windows functions and constants bundled via Win32::API'
   spec.test_files = Dir["test/tc*"]
-  spec.files      = Dir["**/*"].reject{ |f| f.include?('git') }
+  spec.files      = `git ls-files`.split($\)
 
   spec.extra_rdoc_files = [
     'MANIFEST',


### PR DESCRIPTION
When using bundler, `vendor` like directory happens to be included.
This PR fix above issue.